### PR TITLE
Update auto-promise.js

### DIFF
--- a/lib/auto-promise.js
+++ b/lib/auto-promise.js
@@ -150,7 +150,7 @@ function promisify(fn, reverse, collapse) {
   Helper function to parse out argument names, adapted from
   https://github.com/angular/angular.js/blob/43f72066e107445204aee074d7b4f184e9c05d9e/src/auto/injector.js
 */
-var ASYNC_ARROW_ARG = /^async\s(.+?)=>/
+var ASYNC_ARROW_ARG = /^async\s+([\w\d_]+?)\s*=>/
 var ARROW_ARG = /^([^\(]+?)=>/;
 var FN_ARGS = /^[^\(]*\(\s*([^\)]*)\)/m;
 // var FN_ARG_SPLIT = /,/;

--- a/lib/auto-promise.js
+++ b/lib/auto-promise.js
@@ -150,6 +150,7 @@ function promisify(fn, reverse, collapse) {
   Helper function to parse out argument names, adapted from
   https://github.com/angular/angular.js/blob/43f72066e107445204aee074d7b4f184e9c05d9e/src/auto/injector.js
 */
+var ASYNC_ARROW_ARG = /^async\s(.+?)=>/
 var ARROW_ARG = /^([^\(]+?)=>/;
 var FN_ARGS = /^[^\(]*\(\s*([^\)]*)\)/m;
 // var FN_ARG_SPLIT = /,/;
@@ -158,6 +159,6 @@ var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 
 function extractArgs(fn) {
   var fnText = fn.toString().replace(STRIP_COMMENTS, ''),
-      args = fnText.match(ARROW_ARG) || fnText.match(FN_ARGS);
+      args = fnText.match(ASYNC_ARROW_ARG) || fnText.match(ARROW_ARG) || fnText.match(FN_ARGS);
   return args[1].replace(/[\s]*/g, '').split(/,/).filter(item => !!item);
 }


### PR DESCRIPTION
add one more regex to handle async closures with only one argument such as code like:
const closure = async p1 => {}

